### PR TITLE
Actually join channels

### DIFF
--- a/Network/IRC/Client/Internal.hs
+++ b/Network/IRC/Client/Internal.hs
@@ -68,8 +68,7 @@ runner = do
   let initialise = flip runReaderT state $ do
         sendBS $ rawMessage "USER" [encodeUtf8 theUser, "-", "-", encodeUtf8 theReal]
         send $ Nick theNick
-        mapM_ (send . Join) . _channels <$> instanceConfig
-        return ()
+        instanceConfig >>= mapM_ (send . Join) . _channels
 
   -- Run the event loop, and call the disconnect handler if the remote
   -- end closes the socket.

--- a/irc-client.cabal
+++ b/irc-client.cabal
@@ -77,7 +77,6 @@ library
   
   -- Compile with -Wall by default
   ghc-options:         -Wall
-                       -fno-warn-unused-do-bind
   
   -- LANGUAGE extensions used by modules in this package.
   -- other-extensions:    


### PR DESCRIPTION
The previous code resulted in an action of type `IRC (IRC ())`, so
nothing was executed. Thus the unused do-bind warning.