### PR TITLE
Support connecting with a password

### DIFF
--- a/Network/IRC/Client.hs
+++ b/Network/IRC/Client.hs
@@ -134,6 +134,7 @@ defaultIRCConf n = InstanceConfig
   { _nick          = n
   , _username      = n
   , _realname      = n
+  , _password      = Nothing
   , _channels      = []
   , _ctcpVer       = "irc-client-0.3.0.0"
   , _eventHandlers = defaultEventHandlers

--- a/Network/IRC/Client/Internal.hs
+++ b/Network/IRC/Client/Internal.hs
@@ -69,11 +69,13 @@ runner = do
   state <- ircState
 
   -- Set the real- and user-name
-  theUser <- _username <$> instanceConfig
-  theReal <- _realname <$> instanceConfig
+  theUser  <- _username <$> instanceConfig
+  theReal  <- _realname <$> instanceConfig
+  password <- _password <$> instanceConfig
 
   -- Initialise the IRC session
   let initialise = flip runReaderT state $ do
+        mapM_ (\p -> sendBS $ rawMessage "PASS" [encodeUtf8 p]) password
         sendBS $ rawMessage "USER" [encodeUtf8 theUser, "-", "-", encodeUtf8 theReal]
         _onconnect =<< connectionConfig
 

--- a/Network/IRC/Client/Types.hs
+++ b/Network/IRC/Client/Types.hs
@@ -139,6 +139,8 @@ data InstanceConfig s = InstanceConfig
   -- ^ Client username
   , _realname :: Text
   -- ^ Client realname
+  , _password :: Maybe Text
+  -- ^ Client password
   , _channels :: [Text]
   -- ^ Current channels
   , _ctcpVer  :: Text


### PR DESCRIPTION
If a password was set in `InstanceConfig`, this sends a [`PASS` command](https://tools.ietf.org/html/rfc2812#section-3.1.1) right before sending the `USER` message when connecting to the server.