### PR TITLE
Append a newline after each message in fileLogger

### DIFF
--- a/Network/IRC/Client/Internal.hs
+++ b/Network/IRC/Client/Internal.hs
@@ -174,6 +174,7 @@ fileLogger fp origin x = do
     [ formatTime defaultTimeLocale "%c" now
     , if origin == FromServer then "--->" else "<---"
     , init . tail $ show x
+    , "\n"
     ]
 
 -- | Do no logging.


### PR DESCRIPTION
Currently fileLogger is unusable with tools like tail for monitoring irc log.