### PR TITLE
Parametrize `addHandler` with state token

### DIFF
--- a/Network/IRC/Client/Utils.hs
+++ b/Network/IRC/Client/Utils.hs
@@ -40,15 +40,14 @@ delChan tvarI chan = do
   iconf <- readTVar tvarI
   writeTVar tvarI iconf { _channels = filter (/=chan) $ _channels iconf }
 
--- | Add an eventHandler
-addHandler :: EventHandler () -> StatefulIRC () ()
+-- | Add an event handler
+addHandler :: EventHandler s -> StatefulIRC s ()
 addHandler handler = do
   tvarI <- instanceConfigTVar
 
   liftIO . atomically $  do
     iconf <- readTVar tvarI
     writeTVar tvarI iconf { _eventHandlers = handler : _eventHandlers iconf }
-
 
 -- | Send a message to the source of an event.
 reply :: UnicodeEvent -> Text -> StatefulIRC s ()


### PR DESCRIPTION
Fix the `addHandler` function so it can be used if some user state is involved.