### PR TITLE
irc-client.cabal: other-modules: Paths_irc_client; broken by #29

### DIFF
--- a/irc-client.cabal
+++ b/irc-client.cabal
@@ -74,10 +74,11 @@ library
                      , Network.IRC.Client.Internal.Types
                      , Network.IRC.Client.Lens
                      , Network.IRC.Client.Utils
-  
+
   -- Modules included in this library but not exported.
-  -- other-modules:       
-  
+  other-modules:
+    Paths_irc_client
+
   -- Compile with -Wall by default
   ghc-options:         -Wall
   


### PR DESCRIPTION
I forgot about this in #29… this caused linker to fail for users of `irc-client`, complaining about a missing `version` symbol.