### PR TITLE
Sequential handlers and managed threads

### DIFF
--- a/Network/IRC/Client.hs
+++ b/Network/IRC/Client.hs
@@ -167,6 +167,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.ByteString (ByteString)
 import qualified Data.Conduit.Network.TLS as TLS
 import Data.Conduit.TMChan (newTBMChanIO)
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Version (showVersion)
@@ -292,4 +293,4 @@ newIRCState cconf iconf ustate = liftIO $ IRCState cconf
   <*> newTVarIO iconf
   <*> (newTVarIO =<< newTBMChanIO 16)
   <*> newTVarIO Disconnected
-  <*> newTVarIO []
+  <*> newTVarIO S.empty

--- a/Network/IRC/Client/Events.hs
+++ b/Network/IRC/Client/Events.hs
@@ -11,7 +11,8 @@
 -- Portability : CPP, OverloadedStrings, RankNTypes
 --
 -- Events and event handlers. When a message is received from the
--- server, all matching handlers are executed concurrently.
+-- server, all matching handlers are executed sequentially in the
+-- order that they appear in the 'handlers' list.
 module Network.IRC.Client.Events
   ( -- * Handlers
     EventHandler(..)

--- a/Network/IRC/Client/Internal.hs
+++ b/Network/IRC/Client/Internal.hs
@@ -148,8 +148,7 @@ forgetful = awaitForever go where
   go (Left  _) = return ()
   go (Right b) = yield b
 
--- | Block on receiving a message and invoke all matching handlers
--- concurrently.
+-- | Block on receiving a message and invoke all matching handlers.
 eventSink :: MonadIO m => IORef UTCTime -> IRCState s -> Consumer (Event ByteString) m ()
 eventSink lastReceived ircstate = go where
   go = await >>= maybe (return ()) (\event -> do
@@ -164,7 +163,7 @@ eventSink lastReceived ircstate = go where
       iconf <- snapshot instanceConfig ircstate
       forM_ (get handlers iconf) $ \(EventHandler matcher handler) ->
         maybe (pure ())
-              (void . forkIO . flip runIRCAction ircstate . handler (_source event'))
+              (void . flip runIRCAction ircstate . handler (_source event'))
               (matcher event')
 
     -- If disconnected, do not loop.

--- a/Network/IRC/Client/Internal.hs
+++ b/Network/IRC/Client/Internal.hs
@@ -35,6 +35,7 @@ import Data.ByteString (ByteString)
 import Data.Conduit (Producer, Conduit, Consumer, (=$=), ($=), (=$), await, awaitForever, toProducer, yield)
 import Data.Conduit.TMChan (closeTBMChan, isClosedTBMChan, isEmptyTBMChan, sourceTBMChan, writeTBMChan, newTBMChan)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import qualified Data.Set as S
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Time.Clock (NominalDiffTime, UTCTime, addUTCTime, diffUTCTime, getCurrentTime)
@@ -266,7 +267,7 @@ disconnect = do
         -- here, as they might be masking exceptions and not pick up
         -- the 'Disconnect' for a while; just clear the list.
         mapM_ (`throwTo` Disconnect) =<< readTVarIO (_runningThreads s)
-        atomically $ writeTVar (_runningThreads s) []
+        atomically $ writeTVar (_runningThreads s) S.empty
 
       -- If already disconnected, or disconnecting, do nothing.
       _ -> pure ()

--- a/Network/IRC/Client/Internal.hs
+++ b/Network/IRC/Client/Internal.hs
@@ -262,6 +262,12 @@ disconnect = do
           closeTBMChan =<< readTVar (_sendqueue s)
           writeTVar (_connectionState s) Disconnected
 
+        -- Kill all managed threads. Don't wait for them to terminate
+        -- here, as they might be masking exceptions and not pick up
+        -- the 'Disconnect' for a while; just clear the list.
+        mapM_ (`throwTo` Disconnect) =<< readTVarIO (_runningThreads s)
+        atomically $ writeTVar (_runningThreads s) []
+
       -- If already disconnected, or disconnecting, do nothing.
       _ -> pure ()
 

--- a/Network/IRC/Client/Internal/Types.hs
+++ b/Network/IRC/Client/Internal/Types.hs
@@ -113,7 +113,8 @@ data InstanceConfig s = InstanceConfig
   -- ^ The version is sent in response to the CTCP \"VERSION\" request by
   -- the default event handlers.
   , _handlers :: [EventHandler s]
-  -- ^ The registered event handlers
+  -- ^ The registered event handlers. The order in this list is the
+  -- order in which they are executed.
   , _ignore   :: [(Text, Maybe Text)]
   -- ^ List of nicks (optionally restricted to channels) to ignore
   -- messages from. 'Nothing' ignores globally.

--- a/Network/IRC/Client/Internal/Types.hs
+++ b/Network/IRC/Client/Internal/Types.hs
@@ -56,17 +56,18 @@ instance MonadState s (IRC s) where
 -- * State
 
 -- | The state of an IRC session.
-data IRCState s = IRCState { _connectionConfig :: ConnectionConfig s
-                           -- ^Read-only connection configuration
-                           , _userState        :: TVar s
-                           -- ^Mutable user state
-                           , _instanceConfig   :: TVar (InstanceConfig s)
-                           -- ^Mutable instance configuration in STM
-                           , _sendqueue        :: TVar (TBMChan (Message ByteString))
-                           -- ^ Message send queue.
-                           , _connectionState  :: TVar ConnectionState
-                           -- ^State of the connection.
-                           }
+data IRCState s = IRCState
+  { _connectionConfig :: ConnectionConfig s
+  -- ^ Read-only connection configuration
+  , _userState        :: TVar s
+  -- ^ Mutable user state
+  , _instanceConfig   :: TVar (InstanceConfig s)
+  -- ^ Mutable instance configuration in STM
+  , _sendqueue        :: TVar (TBMChan (Message ByteString))
+  -- ^ Message send queue.
+  , _connectionState  :: TVar ConnectionState
+  -- ^ State of the connection.
+  }
 
 -- | The static state of an IRC server connection.
 data ConnectionConfig s = ConnectionConfig

--- a/Network/IRC/Client/Internal/Types.hs
+++ b/Network/IRC/Client/Internal/Types.hs
@@ -18,6 +18,7 @@
 -- of this library.
 module Network.IRC.Client.Internal.Types where
 
+import Control.Concurrent (ThreadId)
 import Control.Concurrent.STM (TVar, atomically, readTVar, writeTVar)
 import Control.Monad.Catch (Exception, MonadThrow, MonadCatch, MonadMask, SomeException)
 import Control.Monad.IO.Class (MonadIO, liftIO)
@@ -67,6 +68,8 @@ data IRCState s = IRCState
   -- ^ Message send queue.
   , _connectionState  :: TVar ConnectionState
   -- ^ State of the connection.
+  , _runningThreads   :: TVar [ThreadId]
+  -- ^ Threads which will be killed when the client disconnects.
   }
 
 -- | The static state of an IRC server connection.
@@ -150,3 +153,10 @@ data Timeout = Timeout
   deriving (Bounded, Enum, Eq, Ord, Read, Show)
 
 instance Exception Timeout
+
+-- | Exception thrown to all managed threads when the client
+-- disconnects.
+data Disconnect = Disconnect
+  deriving (Bounded, Enum, Eq, Ord, Read, Show)
+
+instance Exception Disconnect

--- a/Network/IRC/Client/Internal/Types.hs
+++ b/Network/IRC/Client/Internal/Types.hs
@@ -27,6 +27,7 @@ import Control.Monad.State (MonadState(..))
 import Data.ByteString (ByteString)
 import Data.Conduit (Consumer, Producer)
 import Data.Conduit.TMChan (TBMChan)
+import qualified Data.Set as S
 import Data.Text (Text)
 import Data.Time.Clock (NominalDiffTime)
 import Network.IRC.Conduit (Event(..), Message, Source)
@@ -68,7 +69,7 @@ data IRCState s = IRCState
   -- ^ Message send queue.
   , _connectionState  :: TVar ConnectionState
   -- ^ State of the connection.
-  , _runningThreads   :: TVar [ThreadId]
+  , _runningThreads   :: TVar (S.Set ThreadId)
   -- ^ Threads which will be killed when the client disconnects.
   }
 

--- a/Network/IRC/Client/Utils.hs
+++ b/Network/IRC/Client/Utils.hs
@@ -141,7 +141,7 @@ snapConnState = liftIO . atomically . getConnectionState =<< getIRCState
 -------------------------------------------------------------------------------
 -- Concurrency
 
--- | Fork a thread which will be sent a 'Disconnected' exception when
+-- | Fork a thread which will be thrown a 'Disconnect' exception when
 -- the client disconnects.
 fork :: IRC s () -> IRC s ThreadId
 fork ma = do

--- a/Network/IRC/Client/Utils.hs
+++ b/Network/IRC/Client/Utils.hs
@@ -44,6 +44,7 @@ module Network.IRC.Client.Utils
 import Control.Concurrent (ThreadId, myThreadId, forkFinally)
 import Control.Concurrent.STM (TVar, STM, atomically, modifyTVar)
 import Control.Monad.IO.Class (liftIO)
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import Network.IRC.Conduit (Event(..), Message(..), Source(..))
@@ -149,6 +150,6 @@ fork ma = do
   liftIO $ do
     tid <- forkFinally (runIRCAction ma s) $ \_ -> do
       tid <- myThreadId
-      atomically $ modifyTVar (_runningThreads s) (filter (/=tid))
-    atomically $ modifyTVar (_runningThreads s) (tid:)
+      atomically $ modifyTVar (_runningThreads s) (S.delete tid)
+    atomically $ modifyTVar (_runningThreads s) (S.insert tid)
     pure tid

--- a/irc-client.cabal
+++ b/irc-client.cabal
@@ -88,6 +88,7 @@ library
   -- Other library packages from which modules are imported.
   build-depends:       base                >=4.7   && <5
                      , bytestring          >=0.10  && <0.11
+                     , containers          >=0.1   && <1
                      , conduit             >=1.2   && <1.3
                      , connection          >=0.2   && <0.3
                      , contravariant       >=0.1   && <1.5


### PR DESCRIPTION
This is a fairly large conceptual change, so I'm putting it up for some review before I merge it. This PR has two changes:

1. `EventHandler`s are now executed sequentially, in the order they appear in the `handlers` list. So:
    1. the order of execution of handlers is now totally deterministic and up to the programmer; and
    2. handlers should terminate reasonably quickly (which is probably the case anyway).

2. "Managed" threads are introduced, which are threads which will be killed by the client (by throwing the new `Disconnect` exception) when it disconnects.

Currently killing the managed threads is not part of the on-disconnect handler, it's done in the `disconnect` function. This could be changed if people feel that would be better.

CC @liyang @JanGe (by the way, let me know if you don't want me to ping you like this, but you're the only users I know for certain I have, other than myself)