### PR TITLE
Expose kickHandler

### DIFF
--- a/Network/IRC/Client/Events.hs
+++ b/Network/IRC/Client/Events.hs
@@ -28,6 +28,7 @@ module Network.IRC.Client.Events
 
   -- ** Individual handlers
   , pingHandler
+  , kickHandler
   , ctcpPingHandler
   , ctcpVersionHandler
   , ctcpTimeHandler


### PR DESCRIPTION
Probably an oversight. I want to override one of the default handler, but it seems the only way is then to define the full list of handler, and for that, I need the default `kickHandler`.