### PR TITLE
Bump to 1.1.2.0

### DIFF
--- a/Network/IRC/Client/Internal/Types.hs
+++ b/Network/IRC/Client/Internal/Types.hs
@@ -95,9 +95,9 @@ data ConnectionConfig s = ConnectionConfig
   , _flood      :: NominalDiffTime
   -- ^ The minimum time between two adjacent messages.
   , _timeout    :: NominalDiffTime
-  -- ^ The maximum time between received messages from the server. If no
-  -- messages arrive from the server for this period, the client is sent
-  -- a 'Timeout' exception and disconnects.
+  -- ^ The maximum time (in seconds) between received messages from
+  -- the server. If no messages arrive from the server for this
+  -- period, the client is sent a 'Timeout' exception and disconnects.
   , _onconnect  :: IRC s ()
   -- ^ Action to run after sending the @PASS@ and @USER@ commands to the
   -- server. The default behaviour is to send the @NICK@ command.

--- a/irc-client.cabal
+++ b/irc-client.cabal
@@ -10,7 +10,7 @@ name:                irc-client
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             1.1.1.1
+version:             1.1.2.0
 
 -- A short (one-line) description of the package.
 synopsis:            An IRC client library.
@@ -124,4 +124,4 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/irc-client.git
-  tag:      1.1.1.1
+  tag:      1.1.2.0


### PR DESCRIPTION
The timeout delay is now measured in seconds (#50)

closes #41